### PR TITLE
Add public_key.hrl into includes for chef_req.hrl

### DIFF
--- a/include/chef_req.hrl
+++ b/include/chef_req.hrl
@@ -1,3 +1,6 @@
+
+-include_lib("public_key/include/public_key.hrl").
+
 %% version used in X-CHEF-VERSION header sent to server
 -define(CHEF_VERSION, "0.10.0").
 


### PR DESCRIPTION
It uses rsa_private_key() and throws a compile time error if you haven't
included public_key.hrl
