### PR TITLE
Adding chef_authn as an app, 

### DIFF
--- a/src/chef_req.app.src
+++ b/src/chef_req.app.src
@@ -8,6 +8,7 @@
                   stdlib,
                   crypto,
                   public_key,
+                  chef_authn,
                   ssl,
                   ibrowse
                  ]},


### PR DESCRIPTION
This is so consumers don't have to include it as well when using this lib.
